### PR TITLE
Prepare for FastBoot 1.0 breaking changes

### DIFF
--- a/addon/instance-initializers/ember-useragent.js
+++ b/addon/instance-initializers/ember-useragent.js
@@ -13,7 +13,7 @@ export function initialize(appInstance) {
     userAgent = window.navigator.userAgent;
   }
 
-  assert('No userAgent present in ember-useragent/instance-initializers/browser', userAgent);
+  assert('No userAgent present in ember-useragent/instance-initializers/ember-useragent', userAgent);
 
   setProperties(service, {
     _UAParser: new UAParser(userAgent),
@@ -24,5 +24,9 @@ export function initialize(appInstance) {
 
 export default {
   name: 'ember-useragent-browser',
-  initialize
+  initialize() {
+    if (typeof FastBoot === 'undefined') {
+      initialize(...arguments);
+    }
+  }
 };

--- a/app/instance-initializers/browser/ember-useragent.js
+++ b/app/instance-initializers/browser/ember-useragent.js
@@ -1,1 +1,0 @@
-export { default, initialize } from 'ember-useragent/instance-initializers/browser/ember-useragent';

--- a/app/instance-initializers/ember-useragent.js
+++ b/app/instance-initializers/ember-useragent.js
@@ -1,0 +1,1 @@
+export { default, initialize } from 'ember-useragent/instance-initializers/ember-useragent';

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "broccoli-stew": "^1.4.2",
     "ember-cli-babel": "^5.1.7",
     "ua-parser-js": "^0.7.12"
   },


### PR DESCRIPTION
`process.env.EMBER_CLI_FASTBOOT` and `(instance-)?initializers/(browser|fastboot)` will be gone in FastBoot 1.0. This should now work in pre and post 1.0 versions of `ember-cli-fastboot`. See https://github.com/ember-fastboot/ember-cli-fastboot/issues/360 and https://gist.github.com/kratiahuja/fd073007e10abb9db0a2ec42bc1d7c17 for context.

* uses a FastBoot guard to import the vendor file `ua-parser-js`
* moved `instance-initializer/browser/ember-useragent` to `instance-initializer/ember-useragent` and added FastBoot guard
* `instance-initializer/fastboot/ember-useragent` remains in place for the time being. Current `ember-cli-fastboot` will filter this away, upcoming FastBoot 1.0 (see https://github.com/ember-fastboot/ember-cli-fastboot/pull/369) will move this to `fastboot/instance-initializers/ember-useragent` and include that into `app-fastboot.js`, so in either way this will be only executed in FastBoot. Once support for FastBoot pre 1.0 can be dropped, this can be moved to `fastboot/instance-initializers/ember-useragent` in the repo itself.

Tested this in a real app, with current and future `ember-cli-fastboot`.

@kratiahuja Hope I got it right, as per your suggestions on Slack. Mind having another look?