### PR TITLE
fix: ember-cli-cjs-transform installation bug

### DIFF
--- a/blueprints/ember-useragent/index.js
+++ b/blueprints/ember-useragent/index.js
@@ -2,9 +2,17 @@
 'use strict';
 
 module.exports = {
-  normalizeEntityName: function() {
+  normalizeEntityName () {
     // this prevents an error when the entityName is
     // not specified (since that doesn't actually matter
     // to us
+  },
+
+  afterInstall () {
+    return this.addAddonsToProject({
+      packages: [
+        { name: 'ember-cli-cjs-transform' }
+      ]
+    })
   }
 };

--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
+    "after": [
+      "ember-cli-cjs-transform"
+    ],
     "fastbootDependencies": [
       "ua-parser-js"
     ]


### PR DESCRIPTION
Fix for #20, adding ember-cli-cjs-transform to the host app using Ember CLI `afterInstall` hook.