### PR TITLE
Fixed path-regex in index.js under Windows.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
 
   included(app) {
     // https://github.com/rwjblue/ember-cli-cjs-transform/issues/23#issuecomment-408665511
-    const modulePath = require.resolve('ua-parser-js').match(/node_modules\/.*$/)[0];
+    const modulePath = require.resolve('ua-parser-js').match(/node_modules(\/|\\).*$/)[0];
     app.import(modulePath, {
       using: [
         { transformation: 'cjs', as: 'ua-parser-js' }


### PR DESCRIPTION
This PR fixes a crash when ember-useragent is run under Windows. The problem is that the regex in index.js only matches forward-slashes in path, whereas under Windows it needs to match backslashes.