### PR TITLE
docs(README): add notice about ember-cli-cjs-transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Installation
 ember install ember-useragent
 ```
 
+This also installs [`ember-cli-cjs-transform`](https://github.com/rwjblue/ember-cli-cjs-transform)
+for your app, since it is required. If you are upgrading or it's missing, just install it manually
+or run the `ember-usagent1 blueprint:
+
+```
+ember g ember-useragent
+```
+
+You can find more info in [issue #24](https://github.com/willviles/ember-useragent/issues/24).
+
 ## Usage
 
 Ember UserAgent exposes a (1) service, which is automatically injected into controllers, components and routes, and a (2) template helper.


### PR DESCRIPTION
This PR adds a notice about `ember-cli-cjs-transform` to the README.

Closes #27. Closes #24.

We should open a new tracking issue for the ember-auto-import upgrade.

https://github.com/willviles/ember-useragent/issues/24#issuecomment-426183333:

> > * automatically install ember-cli-cjs-transform during the installation of ember-useragent
> 
> I could implement this as a stop gap until [ef4/ember-auto-import#119](https://github.com/ef4/ember-auto-import/issues/119) drops?

@willviles 	You already implemented it 😄 

https://github.com/willviles/ember-useragent/blob/c3c37ec0cbf2b92ab5e2895a55a0299d1d5a9521/blueprints/ember-useragent/index.js#L11-L17