### PR TITLE
Remove FastBoot dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,9 +83,6 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config",
-    "fastbootDependencies": [
-      "ua-parser-js"
-    ]
+    "configPath": "tests/dummy/config"
   }
 }


### PR DESCRIPTION
The `ember-auto-import` is used to bundle `ua-parser-js`.