### PR TITLE
bump vulnerable ua-parser-js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20175,9 +20175,9 @@
       }
     },
     "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
+      "version": "0.7.30",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.30.tgz",
+      "integrity": "sha512-uXEtSresNUlXQ1QL4/3dQORcGv7+J2ookOG2ybA/ga9+HYEXueT2o+8dUJQkpedsyTyCJ6jCCirRcKtdtx1kbg=="
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ember-auto-import": "^1.5.3",
     "ember-cli-babel": "^7.13.0",
     "ember-cli-htmlbars": "^4.2.0",
-    "ua-parser-js": "^0.7.18"
+    "ua-parser-js": "^0.7.30"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.1.0",


### PR DESCRIPTION
There's a malicious `ua-parser-js` NPM takeover, this PR bumps `ua-parser-js` version to the safe 0.7.30.

Security advisory: https://github.com/advisories/GHSA-pjwm-rvh2-c87w
GH thread: faisalman/ua-parser-js#536
