### PR TITLE
Update `deprecate` import to be from @ember/debug

### DIFF
--- a/addon/services/user-agent.js
+++ b/addon/services/user-agent.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 import { computed, get, set } from '@ember/object';
 import { getOwner } from '@ember/application';
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug';
 import UAParser from 'ua-parser-js';
 
 export default Service.extend({


### PR DESCRIPTION
The previous import was deprecated in Ember 3.0 and removed in 4.0, which is causing ember-useragent to break in 4.0 apps.

https://deprecations.emberjs.com/v3.x#toc_old-deprecate-method-paths